### PR TITLE
Fix video writer crash and UI import

### DIFF
--- a/Painter/run_UI.py
+++ b/Painter/run_UI.py
@@ -13,7 +13,7 @@ import numpy as np
 import qdarkstyle
 import torch
 from PIL import Image
-from PyQt5.QtCore import QCoreApplication, QDir, Qt, QSize
+from PyQt5.QtCore import QCoreApplication, QDir, Qt, QSize, pyqtSlot
 from PyQt5.QtGui import QColor, QImage, QPixmap
 from PyQt5.QtWidgets import (QApplication, QColorDialog, QFileDialog,
                              QGraphicsScene, QMainWindow, QMessageBox, QWidget)


### PR DESCRIPTION
## Summary
- handle absence of CUDA and force FFMPEG writer in video generation
- import `pyqtSlot` for Painter UI
- run image/video generation on CPU when CUDA unavailable

## Testing
- `python -m py_compile gen_videos.py gen_images.py Painter/run_UI.py`


------
https://chatgpt.com/codex/tasks/task_e_68955d13afa4832e884007dac3b8c57b