### PR TITLE
fix ui slot import

### DIFF
--- a/Painter/run_ui.py
+++ b/Painter/run_ui.py
@@ -13,11 +13,27 @@ import numpy as np
 import qdarkstyle
 import torch
 from PIL import Image
-from PyQt5.QtCore import QCoreApplication, QDir, Qt, QSize, pyqtSlot
+from PyQt5.QtCore import QCoreApplication, QDir, Qt, QSize
 from PyQt5.QtGui import QColor, QImage, QPixmap
-from PyQt5.QtWidgets import (QApplication, QColorDialog, QFileDialog,
-                             QGraphicsScene, QMainWindow, QMessageBox, QWidget)
+from PyQt5.QtWidgets import (
+    QApplication,
+    QColorDialog,
+    QFileDialog,
+    QGraphicsScene,
+    QMainWindow,
+    QMessageBox,
+    QWidget,
+)
 from torchvision import transforms, utils
+
+try:  # Some environments may omit ``pyqtSlot``
+    from PyQt5.QtCore import pyqtSlot
+except Exception:  # pragma: no cover - provides graceful fallback
+    def pyqtSlot(*args, **kwargs):  # type: ignore
+        def decorator(func):
+            return func
+
+        return decorator
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import dnnlib


### PR DESCRIPTION
## Summary
- ensure Painter/run_ui.py gracefully handles missing `pyqtSlot` by importing with fallback

## Testing
- `python -m py_compile Painter/run_ui.py`
- `python Painter/run_ui.py -h` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.3 8080])*

------
https://chatgpt.com/codex/tasks/task_e_6895980a2228832eb4d52619f5a3537e