### PR TITLE
Fix missing PyQt imports to avoid NameError

### DIFF
--- a/Painter/ui/ui.py
+++ b/Painter/ui/ui.py
@@ -1,4 +1,6 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtCore import Qt, QSize
+from PyQt5.QtGui import QIcon
 from .util import number_color
 from functools import partial
 import glob


### PR DESCRIPTION
## Summary
- import Qt, QSize and QIcon in UI module to prevent NameError

## Testing
- `python -m py_compile Painter/ui/ui.py Painter/run_ui.py`


------
https://chatgpt.com/codex/tasks/task_e_68959fbbc00c832e9631a7d9e0202720